### PR TITLE
Create shutdown event for synchronization, sACN model shutdown

### DIFF
--- a/color.py
+++ b/color.py
@@ -335,15 +335,11 @@ def Hex(value):
     rgb_t = (int(value[i:i+int(lv/3)], 16) for i in range(0, lv, int(lv/3)))
     return RGB(*rgb_t)
 
+
 class Color:
-    def __init__(self, hsv_tuple, only_rgb=False, brightness_scale=1.0):
+    def __init__(self, hsv_tuple, only_rgb=False):
         self._set_hsv(hsv_tuple)
         self.only_rgb = only_rgb
-        try:
-            self.brightness_scale = float(constrain(brightness_scale, 0.0,1.0))
-        except Exception as e:
-            print("NON-FLOAT sent to brightness_scale, setting to 1.0")
-            self.brightness_scale = constrain(1.0, 0.0,1.0)
 
     def __repr__(self):
         return "rgb=%s hsv=%s" % (self.rgb, self.hsv)
@@ -365,8 +361,8 @@ class Color:
     @property
     def rgb(self):
         "returns a rgb[0-255] tuple"
-        new_t = (self.hsv_t[0], self.hsv_t[1], self.hsv_t[2]*self.brightness_scale)
-        return hsv_to_rgb(new_t)
+        hsv = self.hsv_t
+        return hsv_to_rgb((hsv[0], hsv[1], hsv[2]))
 
     @property
     def hsv(self):
@@ -491,6 +487,15 @@ class Color:
             return 0
         else:
             return self.rgbw[3]
+
+    @staticmethod
+    def scale(color: "Color", factor: float) -> "Color":
+        """
+        Scales the brightness of a Color by a factor in [0,1].
+        """
+        factor = constrain(factor, 0.0, 1.0)
+        (h, s, v) = color.hsv
+        return Color((h, s, v*factor))
 
 if __name__=='__main__':
     import doctest

--- a/go_tri.py
+++ b/go_tri.py
@@ -1,6 +1,3 @@
-import os
-import sys
-import psutil
 import argparse
 import faulthandler
 import logging
@@ -8,16 +5,13 @@ import sys
 import time
 import queue
 import threading
-
 import cherrypy
-
-from cherrypy.process.plugins import SimplePlugin
+import netifaces
 
 from grid import Pyramid
+from model import ModelBase
 from model.sacn_model import sACN
 from model.simulator import SimulatorModel
-
-import netifaces
 import osc_serve
 import shows
 import util
@@ -51,10 +45,16 @@ hi_interp = util.make_interpolater(0.5, 1.0, 1.0, 0.5)
 
 
 class ShowRunner(threading.Thread):
-
-    def __init__(self, pyramid, queue, max_showtime=240, fail_hard=True,brightness_scale=1.0):
+    def __init__(self,
+                 pyramid: Pyramid,
+                 shutdown: threading.Event,
+                 queue: queue.Queue,
+                 max_showtime: int = 240,
+                 fail_hard: bool = True,
+                 brightness_scale: float = 1.0):
         super(ShowRunner, self).__init__(name="ShowRunner")
         self.pyramid = pyramid
+        self.shutdown = shutdown
         self.queue = queue
 
         self.fail_hard = fail_hard
@@ -80,33 +80,6 @@ class ShowRunner(threading.Thread):
         # lower numbers mean faster speeds, higher is slower
         self.speed_x = 1.0
 
-    def restart_program(self,reset_show=None, brightness_scale=1.0):
-        """Restarts the current program, with orig arguments passed back.  reset_show=True will re-start running from a known good show.BUGGY as it assumed the show is the last argument always. """
-
-        if reset_show is None:
-            reset_show = self.show.name
-
-        try:
-            p = psutil.Process(os.getpid())
-            for handler in p.get_open_files() + p.connections():
-                os.close(handler.fd)
-        except Exception as e:
-            logging.error(e)
-
-        time.sleep(1)
-
-        python = sys.executable
-
-        cmd = list(sys.argv)    
-        cmd[-1] = reset_show
-        try: 
-            x = cmd.index('--brightness-scale') 
-            cmd[x+1] = str(brightness_scale)
-        except Exception as e: 
-            cmd.insert(-1,'--brightness-scale') 
-            cmd.insert(-1,str(brightness_scale)) 
-        os.execl(python, python, *cmd)
-
     def status(self):
         if self.running:
             return "Running %s (%d seconds left)" % (self.show.name, self.max_show_time - self.show_runtime)
@@ -130,10 +103,7 @@ class ShowRunner(threading.Thread):
 
     def process_command(self, msg):
         if isinstance(msg, str):
-            if msg == "shutdown":
-                self.running = False
-                logger.info("ShowRunner shutting down")
-            elif msg == "clear":
+            if msg == "clear":
                 self.clear()
                 time.sleep(2)
             elif msg.startswith("run_show:"):
@@ -142,6 +112,8 @@ class ShowRunner(threading.Thread):
                 self.next_show(show_name)
             elif msg.startswith("inc runtime"):
                 self.max_show_time = int(msg.split(':')[1])
+            elif msg.startswith("brightness:"):
+                self.brightness_scale = float(msg[11:])
 
         elif isinstance(msg, tuple):
             logger.debug(f'OSC: {msg}')
@@ -210,7 +182,8 @@ class ShowRunner(threading.Thread):
             print("Next Next Next")
             self.next_show()
 
-        while self.running:
+        # Executes until shutdown event is triggered
+        while not self.shutdown.is_set():
             try:
                 self.check_queue()
 
@@ -218,14 +191,14 @@ class ShowRunner(threading.Thread):
                 self.pyramid.go()
                 if d:
                     real_d = d * self.speed_x
-                    time.sleep(real_d)
+                    self.shutdown.wait(real_d)  # similar to sleep() but can be interrupted
                     self.show_runtime += real_d
                     if self.show_runtime > self.max_show_time:
                         print("max show time elapsed, changing shows")
                         self.next_show()
                 else:
                     print("show is out of frames, waiting...")
-                    time.sleep(2)
+                    self.shutdown.wait(2)
                     self.next_show()
 
             except Exception:
@@ -236,23 +209,15 @@ class ShowRunner(threading.Thread):
                     self.next_show()
 
 
-def osc_listener(q, port=5700):
-    """Create the OSC Listener thread"""
-
-    listen_address = ('0.0.0.0', port)
-    logger.info(f'Starting OSC Listener on {listen_address}')
-    osc_serve.create_server(listen_address, q)
-
-
- 
 class TriangleServer(object):
-    def __init__(self, pyramid, args):
-        self.args = args
-
-        self.brightness_scale = args.brightness_scale
+    def __init__(self, model, pyramid, args):
+        self.model = model
         self.pyramid = pyramid
 
+        self.brightness_scale = args.brightness_scale
+
         self.queue = queue.LifoQueue()
+        self.shutdown = threading.Event()  # Used to signal a shutdown event
 
         self.runner = None
 
@@ -266,15 +231,18 @@ class TriangleServer(object):
         # XXX should it only advertise services that exist?
 
         # OSC listener
-        try:
-            osc_listener(self.queue)
-        except Exception:
-            logger.warning("Can't create OSC listener", exc_info=True)
+        t = threading.Thread(target=osc_serve.create_server, args=(self.shutdown, self.queue))
+        t.start()
 
         # Show runner
         self.runner = ShowRunner(
+            pyramid=self.pyramid,
+            shutdown=self.shutdown,
+            queue=self.queue,
+            max_showtime=args.max_time,
+            fail_hard=args.fail_hard,
+            brightness_scale=self.brightness_scale)
 
-            self.pyramid, self.queue, args.max_time, fail_hard=args.fail_hard, brightness_scale=self.brightness_scale)
         if args.shows:
             print("setting show:", args.shows[0])
             self.runner.next_show(args.shows[0])
@@ -291,29 +259,9 @@ class TriangleServer(object):
             logger.exception("Exception starting tri_grid!!")
 
     def stop(self):
-        if self.running:  # should be safe to call multiple times
-            try:
-                # OSC listener is a daemon thread so it will clean itself up
-
-                # ShowRunner is shut down via the message queue
-                self.queue.put("shutdown")
-
-                self.running = False
-            except Exception:
-                logger.exception("Exception stopping tri_grid!!")
-
-        self.runner.restart_program(str(self.runner.show.name)) 
- 
-        #Fucked up threading handling in SACN preventing chrerrypy from restarting cleanly with any code change (a really REALLY nice feature when writing shows).  I gave up after 2 hrs of debugging mystery threads and applied the sleedge hammer above.  Love- Major
-#      time.sleep(2)  
-#      self.runner.grid._model.__del__() 
-#      del(self.runner.grid._model) 
-#      self.runner.grid._model.sender._output_thread._socket.close() 
-#      self.runner.grid._model.sender._output_thread.join()   
-#      self.runner.grid._model.__del__()   
-
-
-    
+        # safe to call multiple times
+        self.shutdown.set()
+        self.model.stop()
 
     def go_headless(self):
         """Run without the web interface"""
@@ -333,9 +281,8 @@ class TriangleServer(object):
         show_names = [name for (name, cls) in shows.load_shows()]
         print(f'shows: {show_names}')
 
-#        webplugin(cherrypy.engine).subscribe()
-
-        cherrypy.engine.subscribe('stop', self.stop) 
+        # When control of the TriangleServer thread is passed to cherrypy, this registers a callback for shutdown
+        cherrypy.engine.subscribe('stop', self.stop)
         config = {
             'global': {
                 'server.socket_host': '0.0.0.0',
@@ -350,7 +297,6 @@ class TriangleServer(object):
         cherrypy.quickstart(TriangleWeb(self.queue, self.runner, show_names),
                             '/',
                             config=config)
-
 
 
 def dump_panels(pyramid: Pyramid):
@@ -430,15 +376,13 @@ if __name__ == '__main__':
         dump_panels(pyramid)
         sys.exit(0)
 
-    
     model.activate(pyramid.cells)
 
-    app = TriangleServer(pyramid, args)
+    # TriangleServer only needs model for model.stop()
+    app = TriangleServer(model=model, pyramid=pyramid, args=args)
 
     try:
         app.start()  # start related service threads
         app.go_web()  # enter main blocking event loop
     except Exception:
         logger.exception("Unhandled exception running TRI!")
-    finally:
-        app.stop

--- a/grid/face.py
+++ b/grid/face.py
@@ -1,11 +1,10 @@
 from itertools import chain
 from typing import Iterable, Mapping, List, NamedTuple, Optional, Type
 
-from model.base import ModelBase
-
+from model import Model
 from .cell import Cell, Orientation
-from .geom import Address, Coordinate, Geometry, Position, Universe
-from .grid import Grid, Location, Pixel, Query, Selector
+from .geom import Address, Coordinate, Geometry, Universe
+from .grid import Grid
 
 PIXELS_PER_CELL: int = 8
 PIXELS_IN_ROW_TURNAROUND: int = 11
@@ -100,7 +99,7 @@ class Face(Grid):
 
     @classmethod
     def build(cls,
-              model: Type[ModelBase],
+              model: Type[Model],
               spec: List[List[int]],
               start: Address = Address(Universe(1, 1), 4),
               rows_per_panel: int = 11) -> "Face":
@@ -156,7 +155,7 @@ class Face(Grid):
 
         return cls(model, overall_geom, real_panels)
 
-    def __init__(self, model: Type[ModelBase], geom: Geometry, panels: Iterable[Panel]):
+    def __init__(self, model: Type[Model], geom: Geometry, panels: Iterable[Panel]):
         self.model = model
         self.geom = geom
         self.panels = list(panels)

--- a/grid/grid.py
+++ b/grid/grid.py
@@ -2,8 +2,8 @@ from abc import abstractmethod
 import logging
 from typing import Callable, Iterator, Iterable, List, Mapping, NamedTuple, Optional, Union, Type
 
-from color import Color, RGB, HSV
-from model import ModelBase
+from color import Color, RGB
+from model import Model
 from .cell import Cell, Direction
 from .geom import Address, Coordinate, Geometry, Position
 
@@ -21,7 +21,7 @@ Selector = Union[Location,
 class Pixel(NamedTuple):
     cell: Cell
     address: Address
-    model: Type[ModelBase]
+    model: Type[Model]
 
     def set(self, color: Color):
         self.model.set(self.cell, self.address, color)
@@ -32,14 +32,14 @@ class Pixel(NamedTuple):
 
 class Grid(Mapping[Location, Cell]):
     """
-    Grid represents our trianglular cells in a coordinate system.
+    Grid represents our triangular cells in a coordinate system.
 
     A Grid may correspond to a single panel, or an entire side of
     the pyramid.
     """
 
     geom: Geometry
-    model: Type[ModelBase]
+    model: Type[Model]
 
     def cell_exists(self, coord):
         ret_val = True
@@ -101,15 +101,14 @@ class Grid(Mapping[Location, Cell]):
         for pixel in self.pixels(sel):
             pixel.set(color)
 
-    def set_cells(self,cells, color):
+    def set_cells(self, cells, color):
         for c in cells:
             self.set(Coordinate(c[0], c[1]), color)
 
-    def set_all_cells(self,color=None):
+    def set_all_cells(self, color=None):
         for cell in self._cells:
             self.set(Coordinate(cell[0], cell[1]), color)
 
-                        
     def clear(self, color: Color = RGB(0, 0, 0)):
         self.set(self.cells, color)
         self.go()

--- a/grid/pyramid.py
+++ b/grid/pyramid.py
@@ -1,8 +1,7 @@
 from typing import Iterable, Iterator, List, Optional, Type
 
 from color import Color, RGB
-from model.base import ModelBase
-
+from model.base import ModelBase, Model
 from .cell import Cell, Direction
 from .geom import Address, Coordinate, Geometry, Universe
 from .grid import Grid, Pixel, Selector
@@ -63,15 +62,38 @@ class Pyramid:
         self.face = FaceMirror(self.faces[:2])
 
     @property
+    def _model(self) -> Type[Model]:
+        # there should only really be one model
+        return self.faces[0].model
+
+    @property
     def cells(self) -> List[Cell]:
         cells = []
         for face in self.faces:
             cells.extend(face.cells)
         return cells
 
+    @property
+    def brightness(self) -> float:
+        """
+        Getter for current brightness scale [0,1].
+        """
+        return self._model.brightness
+
+    @brightness.setter
+    def brightness(self, value: float):
+        """
+        Setter for current brightness scale [0,1].
+        """
+        if value < 0.0:
+            self._model.brightness = 0.0
+        elif value > 1.0:
+            self._model.brightness = 1.0
+        else:
+            self._model.brightness = value
+
     def go(self):
-        # there should only really be one model
-        self.faces[0].model.go()
+        self._model.go()
 
     def clear(self, color: Color = RGB(0, 0, 0)):
         for face in self.faces:

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,2 +1,2 @@
 # These imports include submodules under the `model` namespace (e.g. model.SimulatorModel is available).
-from .base import ModelBase
+from .base import ModelBase, Model

--- a/model/base.py
+++ b/model/base.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
 from color import Color
-from grid.cell import Address, Cell
-from typing import Iterable, List, Mapping
+from typing import Iterable, List, Mapping, TypeVar
+from grid.cell import Cell
+from grid.geom import Address
 
 
 class ModelBase(ABC):
@@ -32,6 +33,10 @@ class ModelBase(ABC):
     def go(self):
         """Flush all buffered data out to devices."""
         raise NotImplementedError
+
+
+# Useful for type hinting any subclass of ModelBase (i.e. Type[Model])
+Model = TypeVar('Model', bound=ModelBase)
 
 
 def allocate_universes(cells: Iterable[Cell]) -> Mapping[int, List[int]]:

--- a/model/base.py
+++ b/model/base.py
@@ -12,7 +12,12 @@ class ModelBase(ABC):
         """
         Called after Pyramid initialization.
         """
-        pass
+        raise NotImplementedError
+
+    @abstractmethod
+    def stop(self):
+        """Stop model and cleanup resources."""
+        raise NotImplementedError
 
     @abstractmethod
     def set(self, cell: Cell, addr: Address, color: Color):
@@ -27,18 +32,6 @@ class ModelBase(ABC):
     def go(self):
         """Flush all buffered data out to devices."""
         raise NotImplementedError
-
-
-class NullModel(ModelBase):
-    """
-    Discards all set's and go's.
-    """
-
-    def set(self, cell: Cell, addr: Address, color: Color):
-        pass
-
-    def go(self):
-        pass
 
 
 def allocate_universes(cells: Iterable[Cell]) -> Mapping[int, List[int]]:

--- a/model/sacn_model.py
+++ b/model/sacn_model.py
@@ -5,7 +5,6 @@ Pixels are representations of the addressable unit in your object. Cells can hav
 have one LED each.
 """
 import logging
-from threading import Event
 from typing import Iterable
 
 import sacn
@@ -17,9 +16,8 @@ logger = logging.getLogger("pyramidtriangles")
 
 
 class sACN(ModelBase):
-    def __init__(self, bind_address: str, shutdown: Event, brightness_scale=1.0):
-        self.shutdown = shutdown
-        self.brightness_scale = brightness_scale
+    def __init__(self, bind_address: str, brightness: float = 1.0):
+        self.brightness = brightness
         self.sender = sacn.sACNsender(
             bind_address=bind_address,
             universeDiscovery=False,
@@ -47,7 +45,7 @@ class sACN(ModelBase):
         self.stop()
 
     def set(self, cell: Cell, addr: Address, color: Color):
-        color = Color(color.hsv, brightness_scale=self.brightness_scale)
+        color = Color.scale(color, self.brightness)
         try:
             channels = self.leds[addr.universe.id]
         except KeyError:

--- a/model/simulator.py
+++ b/model/simulator.py
@@ -34,7 +34,7 @@ class SimulatorModel(ModelBase):
         self.message_queue.put(msg)
 
     def go(self):
-        while not self.message_queue.empty():
+        while not self.message_queue.empty() and self.sock is not None:
             msg = self.message_queue.get()
             logger.debug(msg)
             self.sock.send(msg.encode())
@@ -42,3 +42,7 @@ class SimulatorModel(ModelBase):
     def activate(self, cells: Iterable[Cell]):
         """No activation needed for simulator."""
         pass
+
+    def stop(self):
+        self.sock.close()
+        self.sock = None

--- a/model/simulator.py
+++ b/model/simulator.py
@@ -5,7 +5,7 @@ import logging
 import queue
 import socket
 
-from typing import Iterable, Union
+from typing import Iterable
 from color import Color
 from grid import Address, Cell
 from .base import ModelBase

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ ola = "^0.10.7"
 jinja2 = "^2.10"
 spectra = "^0.0.11"
 netifaces = "^0.10.9"
-psutil = "^5.6.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"

--- a/shows/__init__.py
+++ b/shows/__init__.py
@@ -11,7 +11,7 @@ from .showbase import ShowBase, load_shows, random_shows
 #from .rain import Rain
 from .circling import Circling
 #from .strobe import Strobe
-from .movingpyramids import MovingPyramids
+#from .movingpyramids import MovingPyramids
 from .marching_hexes import MarchingHexes
 from .top_down import TopDown
 from .tendrils import Tendrils

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -15,6 +15,9 @@ class FakeModel(ModelBase):
     def go(self):
         pass
 
+    def stop(self):
+        pass
+
 
 def test_position_symmetry():
     for curr_id in range(256):

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -20,6 +20,8 @@ class FakeModel(ModelBase):
     def go(self):
         pass
 
+    def stop(self):
+        pass
 
 def single_panel_grid(rows):
     geom = Geometry(origin=Coordinate(0, 0), rows=rows)

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -4,9 +4,8 @@ import shows
 def test_load_shows():
     names = {name for (name, cls) in shows.load_shows()}
     assert {
-        "LeftToRight",
-        "LeftToRightAndBack",
-        "OneByOne",
-        "Random",
-        "UpDown"
+        shows.LeftToRight.__name__,
+        shows.LeftToRightAndBack.__name__,
+        shows.Random.__name__,
+        shows.UpDown.__name__,
     }.issubset(names)

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -13,7 +13,7 @@
 <h3>Change To a New Show Now</h3>
 <ul>
 {% for show in shows %}
-  <li><form action="restart_server" method="post">
+  <li><form action="run_show" method="post">
     <button name="show_name" value="{{show}}">{{show}}</button>
   </form></li>
 {% endfor %}

--- a/web/web.py
+++ b/web/web.py
@@ -1,12 +1,13 @@
-import cherrypy
+from queue import Queue
 import time
-
+from typing import List
+import cherrypy
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 
 class TriangleWeb(object):
     """Web API for running triangle shows."""
-    def __init__(self, queue, runner, show_names):
+    def __init__(self, queue: Queue, runner: "ShowRunner", show_names: List[str]):
         self.queue = queue
         self.runner = runner
         self.shows = show_names
@@ -31,12 +32,6 @@ class TriangleWeb(object):
         raise cherrypy.HTTPRedirect('/')
 
     @cherrypy.expose
-    def restart_server(self, show_name=None):
-        self.runner.restart_program(reset_show=show_name)
-        time.sleep(7)
-        raise cherrypy.HTTPRedirect('/')
-
-    @cherrypy.expose
     def change_run_time(self, run_time=None):
         try:
             run_time = int(run_time)
@@ -49,10 +44,8 @@ class TriangleWeb(object):
 
     @cherrypy.expose
     def change_brightness(self, brightness_scale=1.0):
-        self.runner.restart_program(brightness_scale=brightness_scale)
-        time.sleep(10)
+        self.queue.put(f'brightness:{brightness_scale}')
         raise cherrypy.HTTPRedirect('/')
-
 
     @cherrypy.expose
     def run_show(self, show_name=None):


### PR DESCRIPTION
@johnemajor I believe this fixes the problem (#28) you were having with cherrypy Autoreload failing.

This PR adds a `threading.Event` to coordinate shutdown. Similar to a queue, it is built to be thread-safe. It allows cherrypy to signal shutdown when it's Autoreload detects file changes. The problem was with OSC threads hanging around. In this PR a thread is created to launch OSC, wait for the shutdown event, then cleanup the OSC threads. For sACN, the model is passed to TriangleServer so it can be closed as well.

I think this removes the need for the `restart_server()` method, but please correct me if I've misunderstood.

Also, the `ShowRunner` main loop is more responsive. Previously, `time.sleep(delay)` would prevent a shutdown until possibly `delay` seconds pass. In this PR, that can be interrupted and shutdown immediately.

Brightness scale was moved to the model for applying it and show runner for managing state. It doesn't have to be kept track of or passed in so many places.