### PR TITLE
Fix check for geometry membership

### DIFF
--- a/grid/geom.py
+++ b/grid/geom.py
@@ -164,10 +164,11 @@ class Geometry(NamedTuple):
 
         # convert to relative coordinate
         rel = Coordinate(coord.x - self.origin.x, coord.y - self.origin.y)
+        rel_pos = rel.pos(self)
 
         try:
-            return (0 <= rel.x < self.row_length(rel.pos(self).row) and
-                    0 <= rel.y < self.rows)
+            return (0 <= rel_pos.col < self.row_length(rel_pos.row) and
+                    0 <= rel_pos.row < self.rows)
         except IndexError:
             return False
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -23,6 +23,7 @@ class FakeModel(ModelBase):
     def stop(self):
         pass
 
+
 def single_panel_grid(rows):
     geom = Geometry(origin=Coordinate(0, 0), rows=rows)
     return Face(FakeModel(),
@@ -62,58 +63,36 @@ def test_cells_out_of_bounds():
         triangle[1]
 
 
-def test_cell_attributes():
-    triangle = single_panel_grid(3)
-    assert len(triangle.cells) == 9
-
-    top = triangle[Position(0, 0)]
-    assert top.is_top_corner and top.is_left_edge and top.is_right_edge and top.is_up and top.is_edge
-    assert not top.is_bottom_edge
-
-    left_corner = triangle[Position(2, 0)]
-    assert left_corner.is_left_corner and left_corner.is_left_edge and left_corner.is_bottom_edge and left_corner.is_up
-    assert not left_corner.is_right_edge
-
-    right_corner = triangle[Position(2, 4)]
-    assert right_corner.is_right_corner and right_corner.is_right_edge and right_corner.is_bottom_edge
-    assert right_corner.is_up
-    assert not right_corner.is_left_edge
-
-    inner = triangle[Position(1, 1)]
-    assert inner.is_down
-    assert not inner.is_left_edge and not inner.is_right_edge and not inner.is_bottom_edge and not inner.is_edge
-
-
 def test_cell_neighbors():
     triangle = single_panel_grid(5)
 
-    # TODO: remove cell ID checks
-
     # Upward facing cell
-    (left, middle, right) = triangle.select(edge_neighbors(Position(2, 2)))
-    assert left.id == 5
-    assert middle.id == 12
-    assert right.id == 7
+    (left, middle, right) = triangle.select(edge_neighbors(Coordinate(4, 2)))
+    assert left.coordinate == Coordinate(3, 2)
+    assert middle.coordinate == Coordinate(4, 1)
+    assert right.coordinate == Coordinate(5, 2)
 
-    (left, middle, right) = triangle.select(vertex_neighbors(Position(2, 2)))
-    assert left.id == 10
-    assert middle.id == 2
-    assert right.id == 14
+    (left, middle, right) = triangle.select(vertex_neighbors(Coordinate(4, 2)))
+    assert left.coordinate == Coordinate(2, 1)
+    assert middle.coordinate == Coordinate(4, 3)
+    assert right.coordinate == Coordinate(6, 1)
 
     # Downward facing cell
-    (left, middle, right) = triangle.select(edge_neighbors(Position(2, 1)))
-    assert left.id == 4
-    assert middle.id == 1
-    assert right.id == 6
+    (left, middle, right) = triangle.select(edge_neighbors(Coordinate(3, 2)))
+    assert left.coordinate == Coordinate(2, 2)
+    assert middle.coordinate == Coordinate(3, 3)
+    assert right.coordinate == Coordinate(4, 2)
 
-    (left, middle, right) = triangle.select(vertex_neighbors(Position(2, 1)))
-    assert not left.real
-    assert middle.id == 11
-    assert right.id == 3
+    (left, middle, right) = triangle.select(vertex_neighbors(Coordinate(3, 2)))
+    assert left is None  # left neighbor is off the panel and the whole face geometry
+    assert middle.coordinate == Coordinate(3, 1)
+    assert right.coordinate == Coordinate(5, 3)
 
     # Invalid cell
     assert not any(triangle.select(edge_neighbors(Position(1, -1))))
     assert not any(triangle.select(vertex_neighbors(Position(1, -1))))
+    assert not any(triangle.select(edge_neighbors(Coordinate(2, 4))))
+    assert not any(triangle.select(vertex_neighbors(Coordinate(2, 4))))
 
 
 def test_build_face():


### PR DESCRIPTION
Fixes rendering for some positions. I noticed FuckYourBurn wasn't rendering correctly and debugged down to this check.

Example: `Position(7, 12)` -> `Coordinate(15, 3)`. In the prior check, the (correct) row_length is 15. But the check was using `rel.x` which is 15 and returned false.