### PR TITLE
Refine show loading

### DIFF
--- a/color.py
+++ b/color.py
@@ -84,12 +84,11 @@ import colorsys
 from copy import deepcopy
 from math import fmod, cos, radians
 from typing import Tuple, List, Union
+from model import DisplayColor
 
 __all__ = ['Color', 'Hex', 'HSI', 'HSL', 'HSV', 'RGB', 'RGBW']
 
 # Generic type of int or float
-from model import DisplayColor
-
 V = Union[int, float]
 
 

--- a/go_tri.py
+++ b/go_tri.py
@@ -129,12 +129,9 @@ if __name__ == '__main__':
     parser.add_argument('--bind', help='Local address to use for sACN')
     parser.add_argument('--simulator', dest='simulator', action='store_true')
 
-    parser.add_argument('--list', action='store_true',
-                        help='List available shows')
-    parser.add_argument('--panels', action='store_true',
-                        help='Show face and panel attributes')
-    parser.add_argument('shows', metavar='show_name', type=str, nargs='*',
-                        help='name of show (or shows) to run')
+    parser.add_argument('--list', action='store_true', help='List available shows')
+    parser.add_argument('--panels', action='store_true', help='Show face and panel attributes')
+    parser.add_argument('shows', metavar='show_name', type=str, nargs='*', help='name of show (or shows) to run')
     parser.add_argument('--fail-hard', type=bool, default=True,
                         help="For production runs, when shows fail, the show runner moves to the next show")
 
@@ -159,16 +156,14 @@ if __name__ == '__main__':
             for _, interface, _ in gateways:
                 for a in netifaces.ifaddresses(interface).get(netifaces.AF_INET, []):
                     if a['addr'].startswith('192.168.0'):
-                        logger.info(
-                            f"Auto-detected Pyramid local IP: {a['addr']}")
+                        logger.info(f"Auto-detected Pyramid local IP: {a['addr']}")
                         bind = a['addr']
                         break
                 if bind:
                     break
 
             if not bind:
-                parser.error(
-                    'Failed to auto-detect local IP. Are you on Pyramid Scheme wifi or ethernet?')
+                parser.error('Failed to auto-detect local IP. Are you on Pyramid Scheme wifi or ethernet?')
 
         logger.info("Starting sACN")
         model = sACN(bind)

--- a/go_tri.py
+++ b/go_tri.py
@@ -177,9 +177,5 @@ if __name__ == '__main__':
 
     # TriangleServer only needs model for model.stop()
     app = TriangleServer(model=model, pyramid=pyramid, args=args)
-
-    try:
-        app.start()  # start related service threads
-        app.go_web()  # enter main blocking event loop
-    except Exception:
-        logger.exception("Unhandled exception running TRI!")
+    app.start()  # start related service threads
+    app.go_web()  # enter main blocking event loop

--- a/model/base.py
+++ b/model/base.py
@@ -1,7 +1,5 @@
 from abc import ABC, abstractmethod
 from typing import Iterable, List, Mapping, Tuple
-from grid.cell import Cell
-from grid.geom import Address
 
 
 class DisplayColor(ABC):
@@ -36,7 +34,7 @@ class Model(ABC):
     """Abstract base class for simulators."""
 
     @abstractmethod
-    def activate(self, cells: Iterable[Cell]):
+    def activate(self, cells: Iterable['Cell']):
         """
         Called after Pyramid initialization.
         """
@@ -48,7 +46,7 @@ class Model(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def set(self, cell: Cell, addr: Address, color: DisplayColor):
+    def set(self, cell: 'Cell', addr: 'Address', color: DisplayColor):
         """
         Set one pixel to a particular color.
 
@@ -62,7 +60,7 @@ class Model(ABC):
         raise NotImplementedError
 
 
-def allocate_universes(cells: Iterable[Cell]) -> Mapping[int, List[int]]:
+def allocate_universes(cells: Iterable['Cell']) -> Mapping[int, List[int]]:
     universes = set()
     for cell in cells:
         universes |= cell.universes

--- a/show_runner.py
+++ b/show_runner.py
@@ -87,7 +87,7 @@ class ShowRunner(Thread):
                 break
         [self._process_command(cmd) for cmd in msgs]
 
-    def _process_command(self, msg) -> None:
+    def _process_command(self, msg):
         if isinstance(msg, ClearCmd):
             self.clear()
             self.shutdown.wait(2.0)

--- a/shows/__init__.py
+++ b/shows/__init__.py
@@ -1,25 +1,47 @@
-# These imports include submodules under the `shows` namespace (e.g. shows.UpDown is available).
-from .show import Show, load_shows, random_shows
+import importlib
+import logging
+from functools import lru_cache
+from pathlib import Path
+from random import choice
+from typing import List, Tuple, cast, Iterator, Type
 
-from .circling import Circling
-from .color_pulse import ColorPulse
-from .cycle_hsv import CycleHSV
-from .fuck_your_burn import FuckYourBurn
-from .index_debug import IndexDebug
-from .left_to_right import LeftToRight
-from .left_to_right_and_back import LeftToRightAndBack
-from .gears import Gears
-from .marching_hexes import MarchingHexes
-#from .movingpyramids import MovingPyramids
-#from .one_by_one import OneByOne
-#from .rain import Rain
-from .random_cells import Random
-#from .roar import Roar
-from .sparkles import Sparkles
-#from .stargate import Stargate
-#from .strobe import Strobe
-from .tendrils import Tendrils
-from .top_down import TopDown
-from .up_down import UpDown
-from .warp import Warp
-from .zaphod import Zaphod
+# These imports include submodules under the `shows` namespace.
+from .show import Show
+
+
+logger = logging.getLogger("pyramidtriangles")
+
+
+# This function, like the original version, dynamically imports all files in
+# this directory so individual show files don't need to be imported.
+@lru_cache(maxsize=None)
+def load_shows() -> List[Tuple[str, Show]]:
+    """Return a sorted list of (name, class) tuples of all Show subclasses."""
+    for name in Path(__file__).parent.glob('[!_]*.py'):
+        try:
+            importlib.import_module(f'shows.{name.stem}')
+        except ImportError:
+            logger.warning(f"failed to import {name}")
+
+    return sorted([(cls.__name__, cast(Show, cls)) for cls in show.registry])
+
+
+def random_shows(no_repeat: float = 1/3) -> Iterator[Tuple[str, Type[Show]]]:
+    """
+    Returns an infinite sequence of randomized shows.
+
+    It remembers the last `no_repeat` proportion of items to avoid replaying
+    shows too soon. `no_repeat` defaults to 1/3 of the number of shows.
+
+    Shows marked `debug=True` are not included in the sequence.
+    """
+    seq = load_shows()  # sequence of tuples of (name, class)
+    seen = []
+
+    while True:
+        (name, cls) = choice(seq)
+        if name not in seen and name not in show.debug_registry:
+            seen.append(name)
+            if len(seen) >= no_repeat * len(seq):
+                seen.pop(0)
+            yield name, cls

--- a/shows/index_debug.py
+++ b/shows/index_debug.py
@@ -6,7 +6,7 @@ from grid import Coordinate, Grid, Pyramid, every
 from .show import Show
 
 
-class IndexDebug(Show):
+class IndexDebug(Show, debug=True):
     def __init__(self, pyramid: Pyramid, frame_delay: float = 0.05):
         self.pyramid = pyramid
         self.frame_delay = frame_delay

--- a/shows/movingpyramids.py
+++ b/shows/movingpyramids.py
@@ -5,7 +5,7 @@ from .show import Show
 from util import choose_random_hsv
 
 
-class MovingPyramids(Show):
+class MovingPyramids(Show, disable=True):
     def __init__(self, trimodel, frame_delay=.5):
         self.tri = trimodel.face
         self.time = 0

--- a/shows/one_by_one.py
+++ b/shows/one_by_one.py
@@ -5,7 +5,7 @@ from grid import Grid, Pyramid
 from .show import Show
 
 
-class OneByOne(Show):
+class OneByOne(Show, disable=True):
     grid: Grid
 
     def __init__(self, pyramid: Pyramid, frame_delay: float = 0.9):

--- a/shows/rain.py
+++ b/shows/rain.py
@@ -30,7 +30,7 @@ class RainDrop:
         return y < ground_level
 
 
-class Rain(Show):
+class Rain(Show, disable=True):
     def __init__(self, pyramid: Pyramid, frame_delay=1.0):
         self.tri = pyramid.face
         self.speed = frame_delay

--- a/shows/roar.py
+++ b/shows/roar.py
@@ -3,7 +3,7 @@ from color import HSV
 from grid import Coordinate, Pyramid
 
 
-class Roar(Show):
+class Roar(Show, disable=True):
     """Simple Demo Show. Move from Top of Triangle To Bottom, lighting each row at a time"""
     def __init__(self, pyramid: Pyramid, frame_delay=0.1):
         self.grid = pyramid.panel

--- a/shows/show.py
+++ b/shows/show.py
@@ -1,18 +1,39 @@
 from abc import ABC, abstractmethod
-from functools import lru_cache
-from random import choice
-from typing import Iterator, Tuple, List, cast, Type, Generator
+from typing import Generator
+
+# Will contain all available non-debug shows and debug shows.
+registry = set()
+debug_registry = set()
 
 
 class Show(ABC):
     """
-    Abstract base class for shows.
+    Abstract base class for all shows.
 
-    By inheriting from Show (e.g. `class AwesomeShow(Show):` your show will be found and listed as a runnable
-    show.
-    Your show MUST implement next_frame().
-    Your show MAY override other methods (just description() right now) that will give context about your show.
+    By inheriting from Show (e.g. `class AwesomeShow(Show):` the show will be
+    found and listed as a runnable show.
+
+    Shows can be disabled with a flag: `class UnfinishedShow(Show, disable=True):`
+    Shows can be marked debug with a flag: `class IndexDebug(Show, debug=True):`
+    The flags can be combined.
+
+    Shows MUST implement `next_frame()`.
+    Shows MAY override `description()` to give context about what the show does.
     """
+
+    # This is using the relatively new __init_subclass__() which is executed for
+    # every subclass of Show before __init__(). Each subclass of Show gets added
+    # to the module-level registry list.
+    # This could have used Show.__subclasses__() to find all shows, but this
+    # approach makes it easy and clear to label shows disabled or debug.
+    @classmethod
+    def __init_subclass__(cls, disable=False, debug=False, **kwargs):
+        # https://blog.yuo.be/2018/08/16/__init_subclass__-a-simpler-way-to-implement-class-registries-in-python/
+        super().__init_subclass__(**kwargs)
+        if not disable:
+            registry.add(cls)
+        if debug:
+            debug_registry.add(cls)
 
     @property
     def name(self) -> str:
@@ -26,37 +47,11 @@ class Show(ABC):
         """
         return ''
 
+    # next_frame returns a generator of floats, so the function should `yield` float values.
     @abstractmethod
     def next_frame(self) -> Generator[float, None, None]:
         """
         Draw the next step of the animation.  This is the main loop of the show.  Set some pixels and then 'yield' a
         number to indicate how long you'd like to wait before drawing the next frame.  Delay numbers are in seconds.
         """
-
-
-@lru_cache(maxsize=None)
-def load_shows() -> List[Tuple[str, Show]]:
-    """Return a sorted list of tuples (name, class) of Show subclasses."""
-    return sorted([(cls.__name__, cast(Show, cls)) for cls in Show.__subclasses__()])
-
-
-def random_shows(no_repeat: float = 1/3) -> Iterator[Tuple[str, Type[Show]]]:
-    """
-    Return an infinite sequence of randomized shows.
-
-    Remembers the last 'no_repeat' proportion of items to avoid replaying shows too soon. no_repeat defaults to 1/3 of
-    the sequence.
-    """
-    seq = load_shows()  # sequence of tuples of (name, class)
-    seen = []
-
-    while True:
-        show = choice(seq)
-        while show[0] in seen or 'Debug' in show[0]:
-            show = choice(seq)
-
-        seen.append(show[0])
-        if len(seen) >= no_repeat*len(seq):
-            seen.pop(0)
-
-        yield show
+        raise NotImplementedError

--- a/shows/warp.py
+++ b/shows/warp.py
@@ -1,10 +1,12 @@
 from randomcolor import random_color
 from .show import Show
-from grid import Grid, Pyramid, inset
+from grid import Pyramid, inset
 
 
 class Warp(Show):
-    grid: Grid
+    @staticmethod
+    def description():
+        return 'concentric triangle outlines from out to in'
 
     def __init__(self, pyramid: Pyramid, frame_delay: float = 0.2):
         self.grid = pyramid.face

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -1,11 +1,23 @@
-import shows
+from shows import Show, load_shows
 
 
 def test_load_shows():
-    names = {name for (name, cls) in shows.load_shows()}
+    names = {name for (name, cls) in load_shows()}
     assert {
-        shows.LeftToRight.__name__,
-        shows.LeftToRightAndBack.__name__,
-        shows.Random.__name__,
-        shows.UpDown.__name__,
+        'LeftToRight',
+        'LeftToRightAndBack',
+        'Random',
+        'UpDown',
     }.issubset(names)
+    assert 'DebugShow' in names
+    assert 'DisabledShow' not in names
+
+
+class DebugShow(Show, debug=True):
+    def next_frame(self):
+        pass
+
+
+class DisabledShow(Show, disable=True):
+    def next_frame(self):
+        pass


### PR DESCRIPTION
# Refine show loading

* Brings `load_shows` back to `shows/__init__.py` with easier way to find available shows.
* Shows easily be marked disabled and/or debug with:
```
class UnfinishedShow(Show, disable=True):
```
*  Removes imports from `Model` because there weren't adding anything except type hints. Importing them runs the risk of circular dependencies in the future.
* Description for Warp show.
* Some whitespace.