### PR TITLE
Allow ponzicolor.Color inherit DisplayColor interface

### DIFF
--- a/ponzicolor/color.py
+++ b/ponzicolor/color.py
@@ -1,5 +1,7 @@
-from typing import NamedTuple, Tuple, Union
+from dataclasses import dataclass
+from typing import Tuple, Union
 
+from model import DisplayColor
 from . import blend
 from .space import (
     RGB,
@@ -22,7 +24,8 @@ from .space import (
 )
 
 
-class Color(NamedTuple):
+@dataclass(frozen=True)
+class Color(DisplayColor):
     r: float  # [0-1]
     g: float  # [0-1]
     b: float  # [0-1]
@@ -41,28 +44,28 @@ class Color(NamedTuple):
         return Color(*tuple(int(h[i: i + 2], 16) / 255 for i in range(0, 8, 2)))
 
     @classmethod
-    def from_rgb(cls, rgb: RGB, w: float = 0.0) -> "Color":
-        return cls(rgb.r, rgb.g, rgb.b, w)
+    def from_rgb(cls, rgb: RGB) -> "Color":
+        return cls(rgb.r, rgb.g, rgb.b, 0.0)
 
     @classmethod
-    def from_hsv(cls, hsv: HSV, w: float = 0.0) -> "Color":
-        return cls.from_rgb(hsv_to_srgb(hsv), w)
+    def from_hsv(cls, hsv: HSV) -> "Color":
+        return cls.from_rgb(hsv_to_srgb(hsv))
 
     @classmethod
-    def from_linear_rgb(cls, rgb: LinearRGB, w: float = 0.0) -> "Color":
-        return cls.from_rgb(linear_rgb_to_srgb(rgb), w)
+    def from_linear_rgb(cls, rgb: LinearRGB) -> "Color":
+        return cls.from_rgb(linear_rgb_to_srgb(rgb))
 
     @classmethod
-    def from_xyz(cls, xyz: XYZ, w: float = 0.0) -> "Color":
-        return cls.from_linear_rgb(xyz_to_linear_rgb(xyz), w)
+    def from_xyz(cls, xyz: XYZ) -> "Color":
+        return cls.from_linear_rgb(xyz_to_linear_rgb(xyz))
 
     @classmethod
-    def from_lab(cls, lab: Lab, w: float = 0.0) -> "Color":
-        return cls.from_xyz(lab_to_xyz(lab), w)
+    def from_lab(cls, lab: Lab) -> "Color":
+        return cls.from_xyz(lab_to_xyz(lab))
 
     @classmethod
-    def from_hcl(cls, hcl: HCL, w: float = 0.0) -> "Color":
-        return cls.from_lab(hcl_to_lab(hcl), w)
+    def from_hcl(cls, hcl: HCL) -> "Color":
+        return cls.from_lab(hcl_to_lab(hcl))
 
     @property
     def valid(self) -> bool:
@@ -76,7 +79,7 @@ class Color(NamedTuple):
 
     def blend(self, other: "Color", bias: float) -> "Color":
         return Color.from_hcl(
-            blend.hcl(self.hcl, other.hcl, bias), w=blend.scale(self.w, other.w, bias)
+            blend.hcl(self.hcl, other.hcl, bias)
         )
 
     @property
@@ -162,17 +165,17 @@ class Color(NamedTuple):
         return self.hcl.h
 
 
-def color(chroma: Union[str, RGB, Lab, HCL, HSV], white: float = 0.0) -> Color:
+def color(chroma: Union[str, RGB, Lab, HCL, HSV]) -> Color:
     if isinstance(chroma, str):
         return Color.from_hex(chroma)
     if isinstance(chroma, HCL):
-        return Color.from_hcl(chroma, white)
+        return Color.from_hcl(chroma)
     elif isinstance(chroma, Lab):
-        return Color.from_lab(chroma, white)
+        return Color.from_lab(chroma)
     elif isinstance(chroma, RGB):
-        return Color.from_rgb(chroma, white)
+        return Color.from_rgb(chroma)
     elif isinstance(chroma, HSV):
-        return Color.from_hsv(chroma, white)
+        return Color.from_hsv(chroma)
     else:
         raise TypeError("%r is not an RGB, Lab, HCL, or HSV color" % (chroma,))
 

--- a/ponzicolor/space.py
+++ b/ponzicolor/space.py
@@ -1,11 +1,13 @@
 import colorsys
+from dataclasses import dataclass
 from math import atan2, cos, degrees, sin, sqrt, radians, fmod
-from typing import Callable, NamedTuple
+from typing import Callable
 
 from . import linear
 
 
-class RGB(NamedTuple):
+@dataclass
+class RGB:
     """
     RGB is an sRGB color.
     """
@@ -25,7 +27,8 @@ class RGB(NamedTuple):
         return RGB(c(self.r), c(self.g), c(self.b))
 
 
-class RGBW(NamedTuple):
+@dataclass
+class RGBW:
     """
     RGBW is an sRGB color with an extended white element for saturation.
     """
@@ -35,7 +38,8 @@ class RGBW(NamedTuple):
     w: float  # [0-1]
 
 
-class HSV(NamedTuple):
+@dataclass
+class HSV:
     """
     Hue in [0..360], Saturation and Value in [0..1]. You're better off using HCL, see below.
     """
@@ -44,7 +48,8 @@ class HSV(NamedTuple):
     v: float
 
 
-class Lab(NamedTuple):
+@dataclass
+class Lab:
     """
     Lab is a color in the CIE L*a*b* perceptually-uniform color space.
     """
@@ -54,7 +59,8 @@ class Lab(NamedTuple):
     b: float
 
 
-class HCL(NamedTuple):
+@dataclass
+class HCL:
     """
     HCL is a color in the CIE L*C*h° color space, a polar projection of L*a*b*.
     It's basically a superior HSV.
@@ -65,7 +71,8 @@ class HCL(NamedTuple):
     l: float  # luminance [0-1]
 
 
-class XYZ(NamedTuple):
+@dataclass
+class XYZ:
     """
     XYZ is a color in CIE's standard color space.
     """
@@ -75,7 +82,8 @@ class XYZ(NamedTuple):
     z: float
 
 
-class LinearRGB(NamedTuple):
+@dataclass
+class LinearRGB:
     """
     RGB is a linear color.
     """

--- a/tests/test_ponzicolor.py
+++ b/tests/test_ponzicolor.py
@@ -195,10 +195,15 @@ cases = [
 def test_rgbw():
     for c in cases:
         actual = hsv_to_rgbw(c.hsv)
-        assert actual == approx(c.rgbw, 0.0001)
+        assert actual.r == approx(c.rgbw.r, 0.0001)
+        assert actual.g == approx(c.rgbw.g, 0.0001)
+        assert actual.b == approx(c.rgbw.b, 0.0001)
+        assert actual.w == approx(c.rgbw.w, 0.0001)
     for c in cases:
         actual = rgbw_to_hsv(c.rgbw)
-        assert actual == approx(c.hsv, 0.0001)
+        assert actual.h == approx(c.hsv.h, 0.0001)
+        assert actual.s == approx(c.hsv.s, 0.0001)
+        assert actual.v == approx(c.hsv.v, 0.0001)
 
 
 def test_hsv():


### PR DESCRIPTION
# Allows ponzicolor.Color to inherit DisplayColor interface used elsewhere.

* ponzicolor.Color inheriting from NamedTuple had a conflict with inheriting DisplayColor, so I changed it to use newer dataclass.
* For consistency, changed other NamedTuple subclasses to dataclasses.
* White component has not been used as originally added in, but instead computed only when moving to RGBW. Updated functions to reflect.